### PR TITLE
Bug fix getGeojsonPath(2025) returning NULL

### DIFF
--- a/R/geospatialData_path.R
+++ b/R/geospatialData_path.R
@@ -262,9 +262,8 @@ getGeojsonPath <- function(year = 2026) {
           TRUE ~ "unknown"
         )
       ) %>% deframe()
-  }
 
-  if(year == 2026) {
+  } else if(year == 2026) {
     enframe(files) %>% 
       mutate(
         name = case_when(


### PR DESCRIPTION
Replace two separate `if` blocks with `if/else if` so that the 2025 branch result is returned instead of being shadowed by the NULL from the unevaluated 2026 condition.